### PR TITLE
Fix type casting

### DIFF
--- a/object.go
+++ b/object.go
@@ -165,11 +165,11 @@ func (o *Object) Unref() {
 }
 
 func (o *Object) RefCount() uint {
-	return uint(C._gobject_REFCOUNT(o.p))
+	return uint(C._gobject_REFCOUNT(o.g()))
 }
 
 func (o *Object) RefCountValue() uint {
-	return uint(C._gobject_REFCOUNT_VALUE(o.p))
+	return uint(C._gobject_REFCOUNT_VALUE(o.g()))
 }
 
 func (o *Object) RefSink() *Object {


### PR DESCRIPTION
Resolves:
```
/go/src/github.com/lidouf/glib/object.go:168: cannot use o.p (type C.gpointer) as type *C.struct__GObject in argument to func literal
/go/src/github.com/lidouf/glib/object.go:172: cannot use o.p (type C.gpointer) as type *C.struct__GObject in argument to func literal
```